### PR TITLE
parser: add initial parsing logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +102,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "fluent-uri"
@@ -187,6 +214,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "similar",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,15 +236,30 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "jj-lsp"
 version = "0.1.1-dev1"
 dependencies = [
+ "insta",
+ "lazy_static",
+ "regex",
  "tokio",
  "tower-lsp-server",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -252,7 +307,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -294,6 +349,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +406,35 @@ checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-demangle"
@@ -403,6 +507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,7 +534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -459,7 +569,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -580,6 +690,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,8 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tower-lsp-server = "0.21.0"
+insta = "1.42"
+lazy_static = "1.5"
+regex = "1"
 tokio = { version = "1.44.2", features = ["full"] }
+tower-lsp-server = "0.21"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -2,13 +2,15 @@ use tower_lsp_server::jsonrpc::Result;
 use tower_lsp_server::lsp_types::*;
 use tower_lsp_server::{Client, LanguageServer};
 
+use crate::conflict::Analyzer;
+
 pub struct Backend {
-    _client: Client,
+    client: Client,
 }
 
 impl Backend {
     pub fn new(client: Client) -> Self {
-        Self { _client: client }
+        Self { client }
     }
 }
 
@@ -25,9 +27,24 @@ impl LanguageServer for Backend {
         })
     }
 
-    async fn did_open(&self, _params: DidOpenTextDocumentParams) {}
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let mut analyzer = Analyzer::new(&params.text_document.text);
+        let _conflicts = analyzer.find_conflicts();
+    }
 
-    async fn did_change(&self, _params: DidChangeTextDocumentParams) {}
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let Some(content) = params.content_changes.first() else {
+            self.client
+                .log_message(
+                    MessageType::ERROR,
+                    "LSP client is supposed to always send the complete file contents.",
+                )
+                .await;
+            return;
+        };
+        let mut analyzer = Analyzer::new(&content.text);
+        let _conflicts = analyzer.find_conflicts();
+    }
 
     async fn shutdown(&self) -> Result<()> {
         Ok(())

--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -1,0 +1,208 @@
+use crate::types::{ChangeBlock, Conflict};
+use regex::Regex;
+use std::str::Lines;
+use tower_lsp_server::lsp_types::{Position, Range};
+
+use crate::utils::get_utf16_len;
+
+lazy_static::lazy_static! {
+    static ref DIFF_CONFLICT_START_REGEX: Regex =
+        Regex::new(r"^<<<<<<< Conflict \d+ of \d+$").unwrap();
+    static ref DIFF_CONFLICT_END_REGEX: Regex =
+        Regex::new(r"^>>>>>>> Conflict \d+ of \d+ ends$").unwrap();
+    static ref DIFF_CHANGE_HEADER_REGEX: Regex =
+        Regex::new(r"^%%%%%%% Changes from (base(?: #\d+)? to )?side #\d+$").unwrap();
+    static ref DIFF_CONTENTS_HEADER_REGEX: Regex =
+        Regex::new(r"^\+{7} Contents of side #\d+$").unwrap();
+}
+
+pub struct Analyzer<'a> {
+    conflicts: Vec<Conflict>,
+    lines: Lines<'a>,
+    cur_line: Option<&'a str>,
+    next_line: Option<&'a str>,
+    cur_line_number: u32,
+}
+
+impl<'a> Analyzer<'a> {
+    pub fn new(content: &'a str) -> Self {
+        let mut lines = content.lines();
+        let cur_line = lines.next();
+        let next_line = lines.next();
+
+        Analyzer {
+            conflicts: vec![],
+            lines,
+            cur_line,
+            next_line,
+            cur_line_number: 0,
+        }
+    }
+
+    pub fn find_conflicts(&'a mut self) -> &'a Vec<Conflict> {
+        while let Some(line) = self.next() {
+            if DIFF_CONFLICT_START_REGEX.is_match(line) {
+                self.parse_diff_marker();
+            }
+        }
+        &self.conflicts
+    }
+
+    fn parse_diff_marker(&mut self) {
+        self.next();
+        let mut blocks = vec![];
+
+        while let Some(cur_line) = self.cur_line {
+            if DIFF_CHANGE_HEADER_REGEX.is_match(cur_line) {
+                match self.parse_change_block() {
+                    Some(block) => blocks.push(block),
+                    None => return,
+                }
+            } else if DIFF_CONTENTS_HEADER_REGEX.is_match(cur_line) {
+                match self.parse_contents_block() {
+                    Some(block) => {
+                        blocks.push(block);
+                    }
+                    None => return,
+                }
+            } else {
+                break;
+            }
+        }
+
+        let conflict = Conflict { _blocks: blocks };
+        self.conflicts.push(conflict);
+    }
+
+    fn parse_change_block(&mut self) -> Option<ChangeBlock> {
+        self.next();
+
+        let start_line = self.cur_line_number;
+        let mut content = String::new();
+        let mut next_line = self.cur_line?;
+
+        while !is_known_pattern(next_line) {
+            if next_line.starts_with("+") {
+                if !content.is_empty() {
+                    content.push('\n');
+                }
+                content.push_str(&next_line[1..]);
+            }
+            next_line = self.next()?;
+        }
+
+        let block = ChangeBlock {
+            _content: content,
+            _range: Range::new(
+                Position::new(start_line, 0),
+                Position::new(self.cur_line_number - 1, get_utf16_len(next_line)),
+            ),
+        };
+
+        Some(block)
+    }
+
+    fn parse_contents_block(&mut self) -> Option<ChangeBlock> {
+        self.next();
+
+        let start_line = self.cur_line_number;
+        let mut content = String::new();
+        let mut next_line = self.cur_line?;
+
+        while !is_known_pattern(next_line) {
+            if !content.is_empty() {
+                content.push('\n');
+            }
+            content.push_str(next_line);
+            next_line = self.next()?;
+        }
+
+        let block = ChangeBlock {
+            _content: content,
+            _range: Range::new(
+                Position::new(start_line, 0),
+                Position::new(self.cur_line_number - 1, get_utf16_len(next_line)),
+            ),
+        };
+
+        Some(block)
+    }
+
+    fn next(&mut self) -> Option<&'a str> {
+        self.cur_line = self.next_line;
+        self.next_line = self.lines.next();
+
+        if self.cur_line.is_some() {
+            self.cur_line_number += 1;
+        }
+
+        self.cur_line
+    }
+}
+
+fn is_known_pattern(content: &str) -> bool {
+    DIFF_CHANGE_HEADER_REGEX.is_match(content)
+        || DIFF_CONTENTS_HEADER_REGEX.is_match(content)
+        || DIFF_CONFLICT_END_REGEX.is_match(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_debug_snapshot;
+    use std::fs;
+
+    #[test]
+    fn test_diff_two_sides() {
+        let content = fs::read_to_string("tests/conflicts/diff/two_sides.txt")
+            .expect("Failed to read input file");
+        let mut anayzer = Analyzer::new(&content);
+        let conflicts = anayzer.find_conflicts();
+        assert_debug_snapshot!(conflicts);
+    }
+
+    #[test]
+    fn test_diff_three_sides() {
+        let content = fs::read_to_string("tests/conflicts/diff/three_sides.txt")
+            .expect("Failed to read input file");
+        let mut anayzer = Analyzer::new(&content);
+        let conflicts = anayzer.find_conflicts();
+        assert_debug_snapshot!(conflicts);
+    }
+
+    #[test]
+    fn test_diff_four_sides() {
+        let content = fs::read_to_string("tests/conflicts/diff/four_sides.txt")
+            .expect("Failed to read input file");
+        let mut anayzer = Analyzer::new(&content);
+        let conflicts = anayzer.find_conflicts();
+        assert_debug_snapshot!(conflicts);
+    }
+
+    #[test]
+    fn test_regex_patterns() {
+        let tests = [
+            (DIFF_CONFLICT_START_REGEX.clone(), "<<<<<<< Conflict 1 of 2"),
+            (
+                DIFF_CONFLICT_END_REGEX.clone(),
+                ">>>>>>> Conflict 2 of 2 ends",
+            ),
+            (
+                DIFF_CHANGE_HEADER_REGEX.clone(),
+                "%%%%%%% Changes from base to side #1",
+            ),
+            (
+                DIFF_CHANGE_HEADER_REGEX.clone(),
+                "%%%%%%% Changes from base #1 to side #1",
+            ),
+            (
+                DIFF_CONTENTS_HEADER_REGEX.clone(),
+                "+++++++ Contents of side #2",
+            ),
+        ];
+
+        for (regex_pattern, haystack) in tests {
+            assert!(regex_pattern.is_match(haystack))
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 mod backend;
+mod conflict;
+mod types;
+mod utils;
 
 use backend::Backend;
 use tower_lsp_server::{LspService, Server};

--- a/src/snapshots/jj_lsp__conflict__tests__diff_four_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_four_sides.snap
@@ -1,0 +1,119 @@
+---
+source: src/conflict.rs
+assertion_line: 180
+expression: conflicts
+---
+[
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 14,
+                        character: 39,
+                    },
+                },
+                _content: "1 pez\n2 pez\n3 pez\n4 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 16,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 23,
+                        character: 27,
+                    },
+                },
+                _content: "1 poisson\n2 poisson\n3 poisson\n4 poisson",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 25,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 28,
+                        character: 39,
+                    },
+                },
+                _content: "1 pescare\n2 pescare\n3 pescare\n4 pescare",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 30,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 37,
+                        character: 28,
+                    },
+                },
+                _content: "1 fisch\n2 fisch\n3 fisch\n4 fisch",
+            },
+        ],
+    },
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 42,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 49,
+                        character: 39,
+                    },
+                },
+                _content: "5 pez\n6 pez\n7 pez\n8 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 51,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 58,
+                        character: 27,
+                    },
+                },
+                _content: "5 poisson\n6 poisson\n7 poisson\n8 poisson",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 60,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 63,
+                        character: 39,
+                    },
+                },
+                _content: "5 pescare\n6 pescare\n7 pescare\n8 pescare",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 65,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 72,
+                        character: 28,
+                    },
+                },
+                _content: "5 fisch\n6 fisch\n7 fisch\n8 fisch",
+            },
+        ],
+    },
+]

--- a/src/snapshots/jj_lsp__conflict__tests__diff_three_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_three_sides.snap
@@ -1,0 +1,93 @@
+---
+source: src/conflict.rs
+assertion_line: 171
+expression: conflicts
+---
+[
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 14,
+                        character: 39,
+                    },
+                },
+                _content: "1 pez\n2 pez\n3 pez\n4 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 16,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 23,
+                        character: 27,
+                    },
+                },
+                _content: "1 poisson\n2 poisson\n3 poisson\n4 poisson",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 25,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 28,
+                        character: 28,
+                    },
+                },
+                _content: "1 pescare\n2 pescare\n3 pescare\n4 pescare",
+            },
+        ],
+    },
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 33,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 40,
+                        character: 39,
+                    },
+                },
+                _content: "5 pez\n6 pez\n7 pez\n8 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 42,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 49,
+                        character: 27,
+                    },
+                },
+                _content: "5 poisson\n6 poisson\n7 poisson\n8 poisson",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 51,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 54,
+                        character: 28,
+                    },
+                },
+                _content: "5 pescare\n6 pescare\n7 pescare\n8 pescare",
+            },
+        ],
+    },
+]

--- a/src/snapshots/jj_lsp__conflict__tests__diff_two_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_two_sides.snap
@@ -1,0 +1,67 @@
+---
+source: src/conflict.rs
+assertion_line: 162
+expression: conflicts
+---
+[
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 7,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 14,
+                        character: 27,
+                    },
+                },
+                _content: "1 pez\n2 pez\n3 pez\n4 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 16,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 19,
+                        character: 28,
+                    },
+                },
+                _content: "1 poisson\n2 poisson\n3 poisson\n4 poisson",
+            },
+        ],
+    },
+    Conflict {
+        _blocks: [
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 24,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 31,
+                        character: 27,
+                    },
+                },
+                _content: "5 pez\n6 pez\n7 pez\n8 pez",
+            },
+            ChangeBlock {
+                _range: Range {
+                    start: Position {
+                        line: 33,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 36,
+                        character: 28,
+                    },
+                },
+                _content: "5 poisson\n6 poisson\n7 poisson\n8 poisson",
+            },
+        ],
+    },
+]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,12 @@
+use tower_lsp_server::lsp_types::Range;
+
+#[derive(Debug)]
+pub struct Conflict {
+    pub _blocks: Vec<ChangeBlock>,
+}
+
+#[derive(Debug)]
+pub struct ChangeBlock {
+    pub _range: Range,
+    pub _content: String,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,3 @@
+pub fn get_utf16_len(content: &str) -> u32 {
+    content.chars().map(|c| c.len_utf16()).sum::<usize>() as u32
+}


### PR DESCRIPTION
The parsing logic if far from done, but I am happy with the logic of treating lines as tokens and the overall structure. Currently we only parse diff position markers (and not snapshot and not git).

I'm also quite happy with the testing setup.