### PR TITLE
ci: add checks for tests and clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: cargo test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+
+  clippy:
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  machete:
+    name: cargo machete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Install cargo-machete
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-machete
+          version: latest
+      - name: Run cargo-machete
+        run: cargo machete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,8 +239,6 @@ dependencies = [
  "insta",
  "lazy_static",
  "regex",
- "serde",
- "serde_json",
  "tokio",
  "tower-lsp-server",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,3 @@ lazy_static = "1.5"
 regex = "1"
 tokio = { version = "1.44.2", features = ["full"] }
 tower-lsp-server = "0.21"
-serde_json = "1"
-serde = "1"


### PR DESCRIPTION
Related to #8, but not yet closing.

Adds `cargo test`, `cargo clippy`, and `cargo machete` checks.

PS: The CI check actually caught unsused dependencies that I forgot to remove again :D 