### PR TITLE
parser: add lines that dont start with +/- to content block

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -91,12 +91,21 @@ impl<'a> Analyzer<'a> {
         let mut next_line = self.cur_line?;
 
         while !is_known_pattern(next_line) {
-            if let Some(line_content) = next_line.strip_prefix("+") {
-                if !content.is_empty() {
-                    content.push('\n');
-                }
-                content.push_str(line_content);
+            if next_line.starts_with("-") {
+                next_line = self.next()?;
+                continue;
             }
+
+            if !content.is_empty() {
+                content.push('\n');
+            }
+
+            if let Some(line_content) = next_line.strip_prefix("+") {
+                content.push_str(line_content);
+            } else {
+                content.push_str(next_line);
+            }
+
             next_line = self.next()?;
         }
 

--- a/src/snapshots/jj_lsp__conflict__tests__diff_four_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_four_sides.snap
@@ -1,6 +1,6 @@
 ---
 source: src/conflict.rs
-assertion_line: 190
+assertion_line: 199
 expression: conflicts
 ---
 [
@@ -11,7 +11,7 @@ expression: conflicts
                 character: 0,
             },
             end: Position {
-                line: 38,
+                line: 41,
                 character: 28,
             },
         },
@@ -37,16 +37,16 @@ expression: conflicts
                         character: 39,
                     },
                 },
-                content: "1 pez\n2 pez\n3 pez\n4 pez",
+                content: "foo\n1 pez\n2 pez\n3 pez\n4 pez\nbar\nbaz",
             },
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 15,
+                        line: 18,
                         character: 0,
                     },
                     end: Position {
-                        line: 15,
+                        line: 18,
                         character: 39,
                     },
                 },
@@ -55,11 +55,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 24,
+                        line: 27,
                         character: 0,
                     },
                     end: Position {
-                        line: 24,
+                        line: 27,
                         character: 27,
                     },
                 },
@@ -68,11 +68,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 29,
+                        line: 32,
                         character: 0,
                     },
                     end: Position {
-                        line: 29,
+                        line: 32,
                         character: 39,
                     },
                 },
@@ -83,21 +83,21 @@ expression: conflicts
     Conflict {
         range: Range {
             start: Position {
-                line: 40,
+                line: 43,
                 character: 0,
             },
             end: Position {
-                line: 73,
+                line: 76,
                 character: 28,
             },
         },
         title_range: Range {
             start: Position {
-                line: 40,
+                line: 43,
                 character: 0,
             },
             end: Position {
-                line: 40,
+                line: 43,
                 character: 23,
             },
         },
@@ -105,11 +105,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 41,
+                        line: 44,
                         character: 0,
                     },
                     end: Position {
-                        line: 41,
+                        line: 44,
                         character: 39,
                     },
                 },
@@ -118,11 +118,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 50,
+                        line: 53,
                         character: 0,
                     },
                     end: Position {
-                        line: 50,
+                        line: 53,
                         character: 39,
                     },
                 },
@@ -131,11 +131,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 59,
+                        line: 62,
                         character: 0,
                     },
                     end: Position {
-                        line: 59,
+                        line: 62,
                         character: 27,
                     },
                 },
@@ -144,11 +144,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 64,
+                        line: 67,
                         character: 0,
                     },
                     end: Position {
-                        line: 64,
+                        line: 67,
                         character: 39,
                     },
                 },

--- a/src/snapshots/jj_lsp__conflict__tests__diff_three_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_three_sides.snap
@@ -1,6 +1,6 @@
 ---
 source: src/conflict.rs
-assertion_line: 181
+assertion_line: 190
 expression: conflicts
 ---
 [
@@ -11,7 +11,7 @@ expression: conflicts
                 character: 0,
             },
             end: Position {
-                line: 29,
+                line: 32,
                 character: 28,
             },
         },
@@ -37,16 +37,16 @@ expression: conflicts
                         character: 39,
                     },
                 },
-                content: "1 pez\n2 pez\n3 pez\n4 pez",
+                content: "foo\n1 pez\n2 pez\n3 pez\n4 pez\nbar\nbaz",
             },
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 15,
+                        line: 18,
                         character: 0,
                     },
                     end: Position {
-                        line: 15,
+                        line: 18,
                         character: 39,
                     },
                 },
@@ -55,11 +55,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 24,
+                        line: 27,
                         character: 0,
                     },
                     end: Position {
-                        line: 24,
+                        line: 27,
                         character: 27,
                     },
                 },
@@ -70,21 +70,21 @@ expression: conflicts
     Conflict {
         range: Range {
             start: Position {
-                line: 31,
+                line: 34,
                 character: 0,
             },
             end: Position {
-                line: 55,
+                line: 58,
                 character: 28,
             },
         },
         title_range: Range {
             start: Position {
-                line: 31,
+                line: 34,
                 character: 0,
             },
             end: Position {
-                line: 31,
+                line: 34,
                 character: 23,
             },
         },
@@ -92,11 +92,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 32,
+                        line: 35,
                         character: 0,
                     },
                     end: Position {
-                        line: 32,
+                        line: 35,
                         character: 39,
                     },
                 },
@@ -105,11 +105,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 41,
+                        line: 44,
                         character: 0,
                     },
                     end: Position {
-                        line: 41,
+                        line: 44,
                         character: 39,
                     },
                 },
@@ -118,11 +118,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 50,
+                        line: 53,
                         character: 0,
                     },
                     end: Position {
-                        line: 50,
+                        line: 53,
                         character: 27,
                     },
                 },

--- a/src/snapshots/jj_lsp__conflict__tests__diff_two_sides.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_two_sides.snap
@@ -1,6 +1,6 @@
 ---
 source: src/conflict.rs
-assertion_line: 172
+assertion_line: 181
 expression: conflicts
 ---
 [
@@ -11,7 +11,7 @@ expression: conflicts
                 character: 0,
             },
             end: Position {
-                line: 20,
+                line: 23,
                 character: 28,
             },
         },
@@ -37,16 +37,16 @@ expression: conflicts
                         character: 36,
                     },
                 },
-                content: "1 pez\n2 pez\n3 pez\n4 pez",
+                content: "foo\n1 pez\n2 pez\n3 pez\n4 pez\nbar\nbaz",
             },
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 15,
+                        line: 18,
                         character: 0,
                     },
                     end: Position {
-                        line: 15,
+                        line: 18,
                         character: 27,
                     },
                 },
@@ -57,21 +57,21 @@ expression: conflicts
     Conflict {
         range: Range {
             start: Position {
-                line: 22,
+                line: 25,
                 character: 0,
             },
             end: Position {
-                line: 37,
+                line: 40,
                 character: 28,
             },
         },
         title_range: Range {
             start: Position {
-                line: 22,
+                line: 25,
                 character: 0,
             },
             end: Position {
-                line: 22,
+                line: 25,
                 character: 23,
             },
         },
@@ -79,11 +79,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 23,
+                        line: 26,
                         character: 0,
                     },
                     end: Position {
-                        line: 23,
+                        line: 26,
                         character: 36,
                     },
                 },
@@ -92,11 +92,11 @@ expression: conflicts
             ChangeBlock {
                 title_range: Range {
                     start: Position {
-                        line: 32,
+                        line: 35,
                         character: 0,
                     },
                     end: Position {
-                        line: 32,
+                        line: 35,
                         character: 27,
                     },
                 },

--- a/tests/conflicts/diff/four_sides.md
+++ b/tests/conflicts/diff/four_sides.md
@@ -9,10 +9,13 @@ This is some test file
 -2 fish
 -3 fish
 -4 fish
+foo
 +1 pez
 +2 pez
 +3 pez
 +4 pez
+bar
+baz
 %%%%%%% Changes from base #2 to side #2
 -1 fish
 -2 fish

--- a/tests/conflicts/diff/three_sides.md
+++ b/tests/conflicts/diff/three_sides.md
@@ -9,10 +9,13 @@ This is some test file
 -2 fish
 -3 fish
 -4 fish
+foo
 +1 pez
 +2 pez
 +3 pez
 +4 pez
+bar
+baz
 %%%%%%% Changes from base #2 to side #2
 -1 fish
 -2 fish

--- a/tests/conflicts/diff/two_sides.md
+++ b/tests/conflicts/diff/two_sides.md
@@ -9,10 +9,13 @@ This is some test file
 -2 fish
 -3 fish
 -4 fish
+foo
 +1 pez
 +2 pez
 +3 pez
 +4 pez
+bar
+baz
 +++++++ Contents of side #2
 1 poisson
 2 poisson


### PR DESCRIPTION
If a line in a content block did not start with '+' or '-', we just ignored it.