### PR TITLE
chore: add rust-toolchain.toml with rust 1.88.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Just some housekeeping to make sure we have a defined rust version