### PR TITLE
chore: add statically linked libc build targets on linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,11 @@ jobs:
     strategy:
       matrix:
         include:
+          # TODO(nilskch): remove the gnu targets after bumping the extension version
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-latest }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-latest }
+          - { target: aarch64-unknown-linux-musl, os: ubuntu-latest }
           - { target: x86_64-apple-darwin, os: macos-14 }
           - { target: aarch64-apple-darwin, os: macos-14 }
           - { target: x86_64-pc-windows-msvc, os: windows-latest }


### PR DESCRIPTION
Hopefully fixes #29

`x86_64-unknown-linux-gnu` links libc dynamically per default and `x86_64-unknown-linux-musl` links it statically.

We can't yet remove the gnu target, because the extension tries to find it in the GitHub release. We need to build both targets for now, release a new version, update the extension to select the musl target, and then we can remove the gnu target from the jj-lsp.