### PR TITLE
Implement textDocument/diagnostic pull method

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -255,6 +255,29 @@ impl LanguageServer for Backend {
         Ok(Some(code_actions))
     }
 
+    async fn diagnostic(
+        &self,
+        params: DocumentDiagnosticParams,
+    ) -> Result<DocumentDiagnosticReportResult> {
+        let diagnostics = self
+            .diagnostics_and_code_actions
+            .lock()
+            .await
+            .get(&params.text_document.uri)
+            .map(|items| items.iter().map(|(d, _)| d.clone()).collect())
+            .unwrap_or_default();
+
+        Ok(DocumentDiagnosticReportResult::Report(
+            DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: diagnostics,
+                },
+            }),
+        ))
+    }
+
     async fn shutdown(&self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Return stored diagnostics when the client requests them via the pull diagnostic model (LSP 3.17.0+), instead of returning "method not found". This complements the existing push model (`publishDiagnostics`).

**Problem:** Editors like Zed that use pull diagnostics log repeated errors:

```
Get diagnostics via jj_lsp failed: Method not found
```

The server already advertises `diagnostic_provider` in its capabilities and computes diagnostics on `did_open`/`did_change`, but the `diagnostic` trait method was not overridden, so the default implementation returned `Error::method_not_found()`.

**Fix:** Override the `diagnostic` method to return the already-computed diagnostics for the requested document as a `FullDocumentDiagnosticReport`. If no diagnostics exist for the URI, an empty report is returned.
