### PR TITLE
Support jj 0.37+ detailed conflict marker format

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,24 +1,27 @@
 # Agent Guidelines for jj-lsp
 
 ## Build & Test Commands
+
 - Build: `cargo build`
 - Run: `cargo run`
 - Test all: `cargo test`
-- Test single: `cargo test test_name` (e.g., `cargo test test_diff_two_sides`)  
-- Test with snapshot updates: `cargo test -- --update-snapshots`
+- Test single: `cargo test test_name` (e.g., `cargo test test_diff_two_sides`)
+- Test with snapshot updates: `INSTA_UPDATE=new cargo test`
 - Install: `cargo install --path .`
 
 ## Code Style Guidelines
+
 - **Imports**: Group and order by std, external crates, then internal modules
 - **Error Handling**: Use `Option<T>` for recoverable absences and early returns
 - **Naming**: Use snake_case for variables/functions, CamelCase for types/structs
 - **Types**: Use explicit types for function signatures, prefer ownership over borrowing when appropriate
 - **Formatting**: Follow Rust standard formatting (rustfmt)
 - **Tests**: Use snapshot testing with insta crate for complex test assertions
-- **Regex**: Define regex patterns with lazy_static
+- **Regex**: Define regex patterns with `std::sync::LazyLock`
 - **Modules**: Keep related functionality in dedicated modules
 
 ## Project Structure
+
 - `src/main.rs`: Entry point for the LSP server
 - `src/backend.rs`: LSP backend implementation
 - `src/conflict.rs`: Conflict parsing and analysis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,17 +199,10 @@ name = "jj-lsp"
 version = "0.1.1-dev1"
 dependencies = [
  "insta",
- "lazy_static",
  "regex",
  "tokio",
  "tower-lsp-server",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 insta = "1.43"
-lazy_static = "1.5"
 regex = "1"
 tokio = { version = "1.48", features = ["full"] }
 tower-lsp-server = "0.22"

--- a/src/snapshots/jj_lsp__conflict__tests__diff_two_sides_detailed.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_two_sides_detailed.snap
@@ -1,0 +1,106 @@
+---
+source: src/conflict.rs
+expression: conflicts
+---
+[
+    Conflict {
+        range: Range {
+            start: Position {
+                line: 5,
+                character: 0,
+            },
+            end: Position {
+                line: 24,
+                character: 28,
+            },
+        },
+        title_range: Range {
+            start: Position {
+                line: 5,
+                character: 0,
+            },
+            end: Position {
+                line: 5,
+                character: 23,
+            },
+        },
+        blocks: [
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 6,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 6,
+                        character: 64,
+                    },
+                },
+                content: "foo\n1 pez\n2 pez\n3 pez\n4 pez\nbar\nbaz",
+            },
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 19,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 19,
+                        character: 44,
+                    },
+                },
+                content: "1 poisson\n2 poisson\n3 poisson\n4 poisson",
+            },
+        ],
+    },
+    Conflict {
+        range: Range {
+            start: Position {
+                line: 26,
+                character: 0,
+            },
+            end: Position {
+                line: 42,
+                character: 28,
+            },
+        },
+        title_range: Range {
+            start: Position {
+                line: 26,
+                character: 0,
+            },
+            end: Position {
+                line: 26,
+                character: 23,
+            },
+        },
+        blocks: [
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 27,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 27,
+                        character: 64,
+                    },
+                },
+                content: "5 pez\n6 pez\n7 pez\n8 pez",
+            },
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 37,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 37,
+                        character: 44,
+                    },
+                },
+                content: "5 poisson\n6 poisson\n7 poisson\n8 poisson",
+            },
+        ],
+    },
+]

--- a/src/snapshots/jj_lsp__conflict__tests__diff_whole_file_detailed.snap
+++ b/src/snapshots/jj_lsp__conflict__tests__diff_whole_file_detailed.snap
@@ -1,0 +1,57 @@
+---
+source: src/conflict.rs
+assertion_line: 235
+expression: conflicts
+---
+[
+    Conflict {
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 15,
+                character: 28,
+            },
+        },
+        title_range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 23,
+            },
+        },
+        blocks: [
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 1,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 1,
+                        character: 117,
+                    },
+                },
+                content: "a\nb\nc\nd\ne",
+            },
+            ChangeBlock {
+                title_range: Range {
+                    start: Position {
+                        line: 8,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 8,
+                        character: 44,
+                    },
+                },
+                content: "1\n2\n3\n4\n5\n6",
+            },
+        ],
+    },
+]

--- a/tests/conflicts/diff/two_sides_detailed.md
+++ b/tests/conflicts/diff/two_sides_detailed.md
@@ -1,0 +1,47 @@
+# My header
+
+This is some test file
+
+## Some paragrapgh
+<<<<<<< conflict 1 of 2
+%%%%%%% diff from: rlvkpnrz 2f040964 (rebased revision's parent)
+\\\\\\\        to: rlvkpnrz d44febc2 (rebase destination)
+-1 fish
+-2 fish
+-3 fish
+-4 fish
+foo
++1 pez
++2 pez
++3 pez
++4 pez
+bar
+baz
++++++++ zsuskuln f7705e4f (rebased revision)
+1 poisson
+2 poisson
+3 poisson
+4 poisson
+>>>>>>> conflict 1 of 2 ends
+Some unchanged line in the middle
+<<<<<<< conflict 2 of 2
+%%%%%%% diff from: rlvkpnrz 2f040964 (rebased revision's parent)
+\\\\\\\        to: rlvkpnrz d44febc2 (rebase destination)
+-5 fish
+-6 fish
+-7 fish
+-8 fish
++5 pez
++6 pez
++7 pez
++8 pez
++++++++ zsuskuln f7705e4f (rebased revision)
+5 poisson
+6 poisson
+7 poisson
+8 poisson
+>>>>>>> conflict 2 of 2 ends
+
+## Footer
+
+Lorem ipsum

--- a/tests/conflicts/diff/whole_file_detailed.md
+++ b/tests/conflicts/diff/whole_file_detailed.md
@@ -1,0 +1,16 @@
+<<<<<<< conflict 1 of 1
+%%%%%%% diff from: mntrysmr 14bb871e "Support jj 0.37+ detailed conflict marker format" (parents of rebased revision)
+\\\\\\\        to: lrnzuvum fd58b68f (rebase destination)
++a
++b
++c
++d
++e
++++++++ otsmsqqu e0611812 (rebased revision)
+1
+2
+3
+4
+5
+6
+>>>>>>> conflict 1 of 1 ends


### PR DESCRIPTION
Since jj 0.37.0, conflict markers include detailed labels with change IDs, commit hashes, and descriptions instead of the previous generic `side #N` labels. The start/end markers also changed from uppercase `Conflict` to lowercase `conflict`. Since jj 0.25.0, markers may be longer than 7 characters.

**Before (jj < 0.37):**

```
<<<<<<< Conflict 1 of 1
%%%%%%% Changes from base to side #1
+++++++ Contents of side #2
>>>>>>> Conflict 1 of 1 ends
```

**After (jj 0.37+):**

```
<<<<<<< conflict 1 of 1
%%%%%%% diff from: rlvkpnrz 2f040964 (rebased revision's parent)
\\\\\\\        to: rlvkpnrz d44febc2 (rebase destination)
+++++++ zsuskuln f7705e4f (rebased revision)
>>>>>>> conflict 1 of 1 ends
```

**Changes:**
- Case-insensitive start/end markers (`conflict` vs `Conflict`)
- Accept any label text on `%%%%%%%` and `+++++++` lines (not just `Changes from...` / `Contents of...`)
- Skip `\\\\\\\` continuation lines used for multi-line conflict labels
- Support markers longer than 7 characters (e.g. `<<<<<<<<` for files already containing 7-char marker-like lines)

**Test coverage:** New `test_diff_two_sides_detailed` snapshot test with realistic jj 0.37+ conflict output, plus expanded regex pattern tests covering classic, detailed, and extended-length formats.

**Relevant jj changelog entries:**
- [0.37.0](https://github.com/jj-vcs/jj/blob/main/CHANGELOG.md#0370---2026-01-07): "Conflict labels now contain information about where the sides of a conflict came from"; "`\\\\\\\` markers to indicate the continuation of a conflict label"
- [0.25.0](https://github.com/jj-vcs/jj/blob/main/CHANGELOG.md#0250---2025-01-01): "Conflict markers are now allowed to be longer than 7 characters"
